### PR TITLE
pubsub initial support

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.53.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
           - nightly
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       redis:
-        image: redis:5.0.7
+        image: redis:7.0.2
         ports:
           - 6379:6379
         options: --entrypoint redis-server

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ derive_more = "0.99"
 rand = "0.8"
 env_logger = "0.9"
 ntex = { version = "0.5", features = ["tokio"] }
+futures-util = "0.3.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,3 @@ derive_more = "0.99"
 rand = "0.8"
 env_logger = "0.9"
 ntex = { version = "0.5", features = ["tokio"] }
-futures-util = "0.3.21"

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -1,4 +1,3 @@
-use futures_util::StreamExt;
 use ntex_redis::{cmd, RedisConnector};
 use std::error::Error;
 
@@ -10,11 +9,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let client = RedisConnector::new("127.0.0.1:6379")
         .connect_simple()
         .await?;
-    let mut subscriber = client.stream(cmd::Subscribe("pubsub"))?;
+    let subscriber = client.stream(cmd::Subscribe("pubsub"))?;
 
     ntex::rt::spawn(async move {
         loop {
-            match subscriber.next().await {
+            match subscriber.recv().await {
                 Some(Ok(cmd::SubscribeItem::Subscribed)) => println!("sub: subscribed"),
                 Some(Ok(cmd::SubscribeItem::Message(payload))) => {
                     println!("sub: {:?}", payload)

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -1,0 +1,41 @@
+use futures_util::StreamExt;
+use ntex_redis::{cmd, RedisConnector};
+use std::error::Error;
+
+#[ntex::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+
+    // subscribe
+    let client = RedisConnector::new("127.0.0.1:6379")
+        .connect_simple()
+        .await?;
+    let mut subscriber = client.stream(cmd::Subscribe("pubsub"))?;
+
+    ntex::rt::spawn(async move {
+        loop {
+            match subscriber.next().await {
+                Some(Ok(cmd::SubscribeItem::Subscribed)) => println!("sub: subscribed"),
+                Some(Ok(cmd::SubscribeItem::Message(payload))) => {
+                    println!("sub: {:?}", payload)
+                }
+                Some(Err(e)) => {
+                    println!("sub: {}", e);
+                    return;
+                }
+                _ => unreachable!(),
+            }
+        }
+    });
+
+    // publish
+    let redis = RedisConnector::new("127.0.0.1:6379").connect().await?;
+
+    for i in 0..5 {
+        let value = i.to_string();
+        println!("pub: {}", value);
+        redis.exec(cmd::Publish("pubsub", &value)).await?;
+    }
+
+    Ok(())
+}

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -1,25 +1,20 @@
 use ntex_redis::{cmd, RedisConnector};
 use std::error::Error;
-use std::rc::Rc;
 
 #[ntex::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
     // subscriber
-    let client = Rc::new(
-        RedisConnector::new("127.0.0.1:6379")
-            .connect_simple()
-            .await?,
-    );
+    let client = RedisConnector::new("127.0.0.1:6379")
+        .connect_simple()
+        .await?;
 
-    let client_clone = client.clone();
+    let pubsub = client.subscribe(cmd::Subscribe("pubsub")).unwrap();
 
     ntex::rt::spawn(async move {
-        let subscriber = client_clone.stream(cmd::Subscribe("pubsub")).unwrap();
-
         loop {
-            match subscriber.recv().await {
+            match pubsub.recv().await {
                 Some(Ok(cmd::SubscribeItem::Subscribed(channel))) => {
                     println!("sub: subscribed to {:?}", channel)
                 }
@@ -46,12 +41,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         println!("pub: {}", value);
         redis.exec(cmd::Publish("pubsub", &value)).await?;
     }
-
-    // unsubscribe
-    client.send(cmd::UnSubscribe("pubsub"))?;
-
-    // allow to subscriber recv unsubscribe message
-    ntex::time::sleep(ntex::time::Millis(10)).await;
 
     Ok(())
 }

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -20,11 +20,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         loop {
             match subscriber.recv().await {
-                Some(Ok(cmd::SubscribeItem::Subscribed)) => println!("sub: subscribed"),
-                Some(Ok(cmd::SubscribeItem::Message(payload))) => {
-                    println!("sub: {:?}", payload)
+                Some(Ok(cmd::SubscribeItem::Subscribed(channel))) => {
+                    println!("sub: subscribed to {:?}", channel)
                 }
-                Some(Ok(cmd::SubscribeItem::UnSubscribed)) => println!("sub: unsubscribed"),
+                Some(Ok(cmd::SubscribeItem::Message { channel, payload })) => {
+                    println!("sub: {:?} from {:?}", payload, channel)
+                }
+                Some(Ok(cmd::SubscribeItem::UnSubscribed(channel))) => {
+                    println!("sub: unsubscribed from {:?}", channel)
+                }
                 Some(Err(e)) => {
                     println!("sub: {}", e);
                     return;

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -1,23 +1,30 @@
 use ntex_redis::{cmd, RedisConnector};
 use std::error::Error;
+use std::rc::Rc;
 
 #[ntex::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
-    // subscribe
-    let client = RedisConnector::new("127.0.0.1:6379")
-        .connect_simple()
-        .await?;
-    let subscriber = client.stream(cmd::Subscribe("pubsub"))?;
+    // subscriber
+    let client = Rc::new(
+        RedisConnector::new("127.0.0.1:6379")
+            .connect_simple()
+            .await?,
+    );
+
+    let client_clone = client.clone();
 
     ntex::rt::spawn(async move {
+        let subscriber = client_clone.stream(cmd::Subscribe("pubsub")).unwrap();
+
         loop {
             match subscriber.recv().await {
                 Some(Ok(cmd::SubscribeItem::Subscribed)) => println!("sub: subscribed"),
                 Some(Ok(cmd::SubscribeItem::Message(payload))) => {
                     println!("sub: {:?}", payload)
                 }
+                Some(Ok(cmd::SubscribeItem::UnSubscribed)) => println!("sub: unsubscribed"),
                 Some(Err(e)) => {
                     println!("sub: {}", e);
                     return;
@@ -35,6 +42,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         println!("pub: {}", value);
         redis.exec(cmd::Publish("pubsub", &value)).await?;
     }
+
+    // unsubscribe
+    client.send(cmd::UnSubscribe("pubsub"))?;
+
+    // allow to subscriber recv unsubscribe message
+    ntex::time::sleep(ntex::time::Millis(10)).await;
 
     Ok(())
 }

--- a/src/cmd/connection.rs
+++ b/src/cmd/connection.rs
@@ -88,3 +88,42 @@ impl Command for PingCommand {
         }
     }
 }
+
+/// RESET redis command
+/// This command performs a full reset of the connection's server-side context, mimicking the effect of disconnecting and reconnecting again.
+///
+/// ```rust
+/// use ntex_redis::{cmd, RedisConnector};
+///
+/// #[ntex::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let redis = RedisConnector::new("127.0.0.1:6379").connect_simple().await?;
+///
+///     // reset connection
+///     let response = redis.exec(cmd::Reset()).await?;
+///
+///     assert_eq!(&response, "RESET");
+///
+///     Ok(())
+/// }
+/// ```
+pub fn Reset() -> ResetCommand {
+    ResetCommand(Request::Array(vec![Request::from_static("RESET")]))
+}
+pub struct ResetCommand(Request);
+
+impl Command for ResetCommand {
+    type Output = ByteString;
+
+    fn to_request(self) -> Request {
+        self.0
+    }
+
+    fn to_output(val: Response) -> Result<Self::Output, CommandError> {
+        match val {
+            Response::String(val) => Ok(val),
+            Response::Error(val) => Err(CommandError::Error(val)),
+            _ => Err(CommandError::Output("Unknown response", val)),
+        }
+    }
+}

--- a/src/cmd/connection.rs
+++ b/src/cmd/connection.rs
@@ -97,7 +97,7 @@ impl Command for PingCommand {
 ///
 /// #[ntex::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let redis = RedisConnector::new("127.0.0.1:6379").connect_simple().await?;
+///     let redis = RedisConnector::new("127.0.0.1:6379").connect().await?;
 ///
 ///     // reset connection
 ///     let response = redis.exec(cmd::Reset()).await?;

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -14,13 +14,11 @@ mod strings;
 mod utils;
 
 pub use self::auth::Auth;
-pub use self::connection::{Ping, Select};
+pub use self::connection::{Ping, Reset, Select};
 pub use self::hashes::{HDel, HGet, HGetAll, HIncrBy, HLen, HSet};
 pub use self::keys::{Del, Exists, Expire, ExpireAt, Keys, Ttl, TtlResult};
 pub use self::lists::{LIndex, LPop, LPush, RPop, RPush};
-pub use self::pubsub::{
-    PubSubCommand, Publish, Subscribe, SubscribeItem, SubscribeOutputCommand, UnSubscribe,
-};
+pub use self::pubsub::{Publish, Subscribe, SubscribeItem, UnSubscribe};
 pub use self::strings::{Get, IncrBy, Set};
 
 /// Trait implemented by types that can be used as redis commands
@@ -41,6 +39,7 @@ pub mod commands {
     pub use super::hashes::{HDelCommand, HGetAllCommand, HSetCommand};
     pub use super::keys::{KeysCommand, KeysPatternCommand, TtlCommand};
     pub use super::lists::LPushCommand;
+    pub use super::pubsub::{PubSubCommand, SubscribeOutputCommand};
     pub use super::strings::SetCommand;
     pub use super::utils::{BulkOutputCommand, IntOutputCommand};
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -18,7 +18,7 @@ pub use self::connection::{Ping, Select};
 pub use self::hashes::{HDel, HGet, HGetAll, HIncrBy, HLen, HSet};
 pub use self::keys::{Del, Exists, Expire, ExpireAt, Keys, Ttl, TtlResult};
 pub use self::lists::{LIndex, LPop, LPush, RPop, RPush};
-pub use self::pubsub::{Publish, Subscribe, SubscribeItem};
+pub use self::pubsub::{Publish, Subscribe, SubscribeItem, UnSubscribe};
 pub use self::strings::{Get, IncrBy, Set};
 
 /// Trait implemented by types that can be used as redis commands

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -18,7 +18,10 @@ pub use self::connection::{Ping, Reset, Select};
 pub use self::hashes::{HDel, HGet, HGetAll, HIncrBy, HLen, HSet};
 pub use self::keys::{Del, Exists, Expire, ExpireAt, Keys, Ttl, TtlResult};
 pub use self::lists::{LIndex, LPop, LPush, RPop, RPush};
-pub use self::pubsub::{Publish, Subscribe, SubscribeItem, UnSubscribe};
+pub use self::pubsub::{
+    PSubscribe, PUnSubscribe, Publish, SPublish, SSubscribe, SUnSubscribe, Subscribe,
+    SubscribeItem, UnSubscribe,
+};
 pub use self::strings::{Get, IncrBy, Set};
 
 /// Trait implemented by types that can be used as redis commands

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -18,7 +18,9 @@ pub use self::connection::{Ping, Select};
 pub use self::hashes::{HDel, HGet, HGetAll, HIncrBy, HLen, HSet};
 pub use self::keys::{Del, Exists, Expire, ExpireAt, Keys, Ttl, TtlResult};
 pub use self::lists::{LIndex, LPop, LPush, RPop, RPush};
-pub use self::pubsub::{Publish, Subscribe, SubscribeItem, UnSubscribe};
+pub use self::pubsub::{
+    PubSubCommand, Publish, Subscribe, SubscribeItem, SubscribeOutputCommand, UnSubscribe,
+};
 pub use self::strings::{Get, IncrBy, Set};
 
 /// Trait implemented by types that can be used as redis commands

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -9,6 +9,7 @@ mod connection;
 mod hashes;
 mod keys;
 mod lists;
+mod pubsub;
 mod strings;
 mod utils;
 
@@ -17,6 +18,7 @@ pub use self::connection::{Ping, Select};
 pub use self::hashes::{HDel, HGet, HGetAll, HIncrBy, HLen, HSet};
 pub use self::keys::{Del, Exists, Expire, ExpireAt, Keys, Ttl, TtlResult};
 pub use self::lists::{LIndex, LPop, LPush, RPop, RPush};
+pub use self::pubsub::{Publish, Subscribe, SubscribeItem};
 pub use self::strings::{Get, IncrBy, Set};
 
 /// Trait implemented by types that can be used as redis commands

--- a/src/cmd/pubsub.rs
+++ b/src/cmd/pubsub.rs
@@ -85,34 +85,30 @@ impl TryFrom<Response> for SubscribeItem {
 
         match &mtype {
             s if s == &TYPE_SUBSCRIBE || s == &TYPE_SSUBSCRIBE || s == &TYPE_PSUBSCRIBE => {
-                return Ok(SubscribeItem::Subscribed(channel));
+                Ok(SubscribeItem::Subscribed(channel))
             }
             s if s == &TYPE_UNSUBSCRIBE || s == &TYPE_SUNSUBSCRIBE || s == &TYPE_PUNSUBSCRIBE => {
-                return Ok(SubscribeItem::UnSubscribed(channel));
+                Ok(SubscribeItem::UnSubscribed(channel))
             }
             s if s == &TYPE_MESSAGE || s == &TYPE_SMESSAGE || s == &TYPE_PMESSAGE => {
-                let payload = if let Some(payload) = payload.0.left() {
-                    payload
+                if let Some(payload) = payload.0.left() {
+                    Ok(SubscribeItem::Message {
+                        pattern,
+                        channel,
+                        payload,
+                    })
                 } else {
-                    return Err(CommandError::Output(
+                    Err(CommandError::Output(
                         "Subscription message payload is not bytes",
                         Response::Nil,
-                    ));
-                };
-
-                return Ok(SubscribeItem::Message {
-                    pattern,
-                    channel,
-                    payload,
-                });
+                    ))
+                }
             }
-            _ => {
-                return Err(CommandError::Output(
-                    "Subscription message type unknown",
-                    Response::Bytes(mtype),
-                ));
-            }
-        };
+            _ => Err(CommandError::Output(
+                "Subscription message type unknown",
+                Response::Bytes(mtype),
+            )),
+        }
     }
 }
 

--- a/src/cmd/pubsub.rs
+++ b/src/cmd/pubsub.rs
@@ -16,12 +16,6 @@ const TYPE_PMESSAGE: Bytes = Bytes::from_static(b"pmessage");
 
 pub trait PubSubCommand {}
 
-// #[derive(Debug, PartialEq)]
-// pub struct Channel {
-//     pub name: Bytes,
-//     pub pattern: Option<Bytes>,
-// }
-
 #[derive(Debug, PartialEq)]
 pub enum SubscribeItem {
     Subscribed(Bytes),

--- a/src/cmd/pubsub.rs
+++ b/src/cmd/pubsub.rs
@@ -1,0 +1,73 @@
+use super::{utils, Command, CommandError};
+use ntex::util::Bytes;
+
+use crate::codec::{BulkString, Request, Response};
+
+const TYPE_SUBSCRIBE: Bytes = Bytes::from_static(b"subscribe");
+const TYPE_MESSAGE: Bytes = Bytes::from_static(b"message");
+
+/// Publish redis command
+pub fn Publish<T, V>(key: T, value: V) -> utils::IntOutputCommand
+where
+    BulkString: From<T> + From<V>,
+{
+    utils::IntOutputCommand(Request::Array(vec![
+        Request::from_static("PUBLISH"),
+        Request::BulkString(key.into()),
+        Request::BulkString(value.into()),
+    ]))
+}
+
+#[derive(Debug, PartialEq)]
+pub enum SubscribeItem {
+    Subscribed,
+    Message(Bytes),
+}
+
+pub struct SubscribeOutputCommand(pub(crate) Request);
+
+impl Command for SubscribeOutputCommand {
+    type Output = SubscribeItem;
+
+    fn to_request(self) -> Request {
+        self.0
+    }
+
+    fn to_output(val: Response) -> Result<Self::Output, CommandError> {
+        match val {
+            Response::Array(ref v) => match v.get(0) {
+                Some(Response::Bytes(t)) => {
+                    if t == &TYPE_SUBSCRIBE {
+                        return Ok(SubscribeItem::Subscribed);
+                    }
+                    if t == &TYPE_MESSAGE {
+                        return match v.get(2) {
+                            Some(payload) => match payload {
+                                Response::Bytes(m) => Ok(SubscribeItem::Message(m.clone())),
+                                _ => {
+                                    Err(CommandError::Output("Cannot parse message payload", val))
+                                }
+                            },
+                            _ => Err(CommandError::Output("Empty messsage payload", val)),
+                        };
+                    }
+
+                    Err(CommandError::Output("Unknown message type", val))
+                }
+                _ => Err(CommandError::Output("Cannot parse message type", val)),
+            },
+            _ => Err(CommandError::Output("Cannot parse response", val)),
+        }
+    }
+}
+
+/// Subscribe redis command
+pub fn Subscribe<T>(key: T) -> SubscribeOutputCommand
+where
+    BulkString: From<T>,
+{
+    SubscribeOutputCommand(Request::Array(vec![
+        Request::from_static("SUBSCRIBE"),
+        Request::BulkString(key.into()),
+    ]))
+}

--- a/src/cmd/pubsub.rs
+++ b/src/cmd/pubsub.rs
@@ -6,15 +6,31 @@ use crate::codec::{BulkString, Request, Response};
 
 const TYPE_SUBSCRIBE: Bytes = Bytes::from_static(b"subscribe");
 const TYPE_UNSUBSCRIBE: Bytes = Bytes::from_static(b"unsubscribe");
+const TYPE_SSUBSCRIBE: Bytes = Bytes::from_static(b"ssubscribe");
+const TYPE_SUNSUBSCRIBE: Bytes = Bytes::from_static(b"sunsubscribe");
+const TYPE_PSUBSCRIBE: Bytes = Bytes::from_static(b"psubscribe");
+const TYPE_PUNSUBSCRIBE: Bytes = Bytes::from_static(b"punsubscribe");
 const TYPE_MESSAGE: Bytes = Bytes::from_static(b"message");
+const TYPE_SMESSAGE: Bytes = Bytes::from_static(b"smessage");
+const TYPE_PMESSAGE: Bytes = Bytes::from_static(b"pmessage");
 
 pub trait PubSubCommand {}
+
+// #[derive(Debug, PartialEq)]
+// pub struct Channel {
+//     pub name: Bytes,
+//     pub pattern: Option<Bytes>,
+// }
 
 #[derive(Debug, PartialEq)]
 pub enum SubscribeItem {
     Subscribed(Bytes),
     UnSubscribed(Bytes),
-    Message { channel: Bytes, payload: Bytes },
+    Message {
+        pattern: Option<Bytes>,
+        channel: Bytes,
+        payload: Bytes,
+    },
 }
 
 struct MessagePayload(Either<Bytes, i64>);
@@ -35,33 +51,68 @@ impl TryFrom<Response> for SubscribeItem {
     type Error = CommandError;
 
     fn try_from(val: Response) -> Result<Self, Self::Error> {
-        let (mtype, channel, payload) = <(Bytes, Bytes, MessagePayload)>::try_from(val)?;
-
-        if mtype == &TYPE_SUBSCRIBE {
-            return Ok(SubscribeItem::Subscribed(channel));
-        }
-
-        if mtype == &TYPE_UNSUBSCRIBE {
-            return Ok(SubscribeItem::UnSubscribed(channel));
-        }
-
-        if mtype != &TYPE_MESSAGE {
-            return Err(CommandError::Output(
-                "Subscription message type unknown",
-                Response::Bytes(mtype),
-            ));
-        }
-
-        let payload = if let Some(payload) = payload.0.left() {
-            payload
-        } else {
-            return Err(CommandError::Output(
-                "Subscription message payload is not bytes",
-                Response::Nil,
-            ));
+        let (mtype, pattern, channel, payload) = match val {
+            Response::Array(ary) => match ary.len() {
+                // subscribe or ssubscribe message
+                3 => {
+                    let mut ary_iter = ary.into_iter();
+                    (
+                        Bytes::try_from(ary_iter.next().expect("No value"))?,
+                        None,
+                        Bytes::try_from(ary_iter.next().expect("No value"))?,
+                        MessagePayload::try_from(ary_iter.next().expect("No value"))?,
+                    )
+                }
+                // psubscribe message
+                4 => {
+                    let mut ary_iter = ary.into_iter();
+                    (
+                        Bytes::try_from(ary_iter.next().expect("No value"))?,
+                        Some(Bytes::try_from(ary_iter.next().expect("No value"))?),
+                        Bytes::try_from(ary_iter.next().expect("No value"))?,
+                        MessagePayload::try_from(ary_iter.next().expect("No value"))?,
+                    )
+                }
+                _ => {
+                    return Err(CommandError::Output(
+                        "Array needs to be 3 or 4 elements",
+                        Response::Array(ary),
+                    ))
+                }
+            },
+            _ => return Err(CommandError::Output("Unexpected value", val)),
         };
 
-        Ok(SubscribeItem::Message { channel, payload })
+        match &mtype {
+            s if s == &TYPE_SUBSCRIBE || s == &TYPE_SSUBSCRIBE || s == &TYPE_PSUBSCRIBE => {
+                return Ok(SubscribeItem::Subscribed(channel));
+            }
+            s if s == &TYPE_UNSUBSCRIBE || s == &TYPE_SUNSUBSCRIBE || s == &TYPE_PUNSUBSCRIBE => {
+                return Ok(SubscribeItem::UnSubscribed(channel));
+            }
+            s if s == &TYPE_MESSAGE || s == &TYPE_SMESSAGE || s == &TYPE_PMESSAGE => {
+                let payload = if let Some(payload) = payload.0.left() {
+                    payload
+                } else {
+                    return Err(CommandError::Output(
+                        "Subscription message payload is not bytes",
+                        Response::Nil,
+                    ));
+                };
+
+                return Ok(SubscribeItem::Message {
+                    pattern,
+                    channel,
+                    payload,
+                });
+            }
+            _ => {
+                return Err(CommandError::Output(
+                    "Subscription message type unknown",
+                    Response::Bytes(mtype),
+                ));
+            }
+        };
     }
 }
 
@@ -93,7 +144,7 @@ impl Command for UnSubscribeOutputCommand {
     }
 }
 
-/// Publish redis command
+/// PUBLISH redis command
 pub fn Publish<T, V>(key: T, value: V) -> utils::IntOutputCommand
 where
     BulkString: From<T> + From<V>,
@@ -105,26 +156,94 @@ where
     ]))
 }
 
-/// Subscribe redis command
-pub fn Subscribe<T>(key: T) -> SubscribeOutputCommand
+/// SPUBLISH redis command
+pub fn SPublish<T, V>(key: T, value: V) -> utils::IntOutputCommand
 where
-    BulkString: From<T>,
+    BulkString: From<T> + From<V>,
 {
-    SubscribeOutputCommand(Request::Array(vec![
-        Request::from_static("SUBSCRIBE"),
+    utils::IntOutputCommand(Request::Array(vec![
+        Request::from_static("SPUBLISH"),
         Request::BulkString(key.into()),
+        Request::BulkString(value.into()),
     ]))
 }
 
-/// Unsubscribe redis command
-pub fn UnSubscribe<T>(key: T) -> UnSubscribeOutputCommand
+/// SUBSCRIBE redis command
+pub fn Subscribe<T>(channels: Vec<T>) -> SubscribeOutputCommand
 where
     BulkString: From<T>,
 {
-    UnSubscribeOutputCommand(Request::Array(vec![
-        Request::from_static("UNSUBSCRIBE"),
-        Request::BulkString(key.into()),
-    ]))
+    let mut req = Request::from_static("SUBSCRIBE");
+    for channel in channels {
+        req = req.add(Request::BulkString(channel.into()));
+    }
+    SubscribeOutputCommand(req)
+}
+
+/// UNSUBSCRIBE redis command
+pub fn UnSubscribe<T>(channels: Option<Vec<T>>) -> UnSubscribeOutputCommand
+where
+    BulkString: From<T>,
+{
+    let mut req = Request::from_static("UNSUBSCRIBE");
+    if let Some(channels) = channels {
+        for channel in channels {
+            req = req.add(Request::BulkString(channel.into()));
+        }
+    }
+    UnSubscribeOutputCommand(req)
+}
+
+/// SSUBSCRIBE redis command
+pub fn SSubscribe<T>(channels: Vec<T>) -> SubscribeOutputCommand
+where
+    BulkString: From<T>,
+{
+    let mut req = Request::from_static("SSUBSCRIBE");
+    for channel in channels {
+        req = req.add(Request::BulkString(channel.into()));
+    }
+    SubscribeOutputCommand(req)
+}
+
+/// SUNSUBSCRIBE redis command
+pub fn SUnSubscribe<T>(channels: Option<Vec<T>>) -> UnSubscribeOutputCommand
+where
+    BulkString: From<T>,
+{
+    let mut req = Request::from_static("SUNSUBSCRIBE");
+    if let Some(channels) = channels {
+        for channel in channels {
+            req = req.add(Request::BulkString(channel.into()));
+        }
+    }
+    UnSubscribeOutputCommand(req)
+}
+
+/// PSUBSCRIBE redis command
+pub fn PSubscribe<T>(channels: Vec<T>) -> SubscribeOutputCommand
+where
+    BulkString: From<T>,
+{
+    let mut req = Request::from_static("PSUBSCRIBE");
+    for channel in channels {
+        req = req.add(Request::BulkString(channel.into()));
+    }
+    SubscribeOutputCommand(req)
+}
+
+/// PUNSUBSCRIBE redis command
+pub fn PUnSubscribe<T>(channels: Option<Vec<T>>) -> UnSubscribeOutputCommand
+where
+    BulkString: From<T>,
+{
+    let mut req = Request::from_static("PUNSUBSCRIBE");
+    if let Some(channels) = channels {
+        for channel in channels {
+            req = req.add(Request::BulkString(channel.into()));
+        }
+    }
+    UnSubscribeOutputCommand(req)
 }
 
 impl PubSubCommand for SubscribeOutputCommand {}

--- a/src/cmd/pubsub.rs
+++ b/src/cmd/pubsub.rs
@@ -1,5 +1,5 @@
 use super::{utils, Command, CommandError};
-use ntex::util::Bytes;
+use ntex::util::{Bytes, Either};
 use std::convert::TryFrom;
 
 use crate::codec::{BulkString, Request, Response};
@@ -8,76 +8,58 @@ const TYPE_SUBSCRIBE: Bytes = Bytes::from_static(b"subscribe");
 const TYPE_UNSUBSCRIBE: Bytes = Bytes::from_static(b"unsubscribe");
 const TYPE_MESSAGE: Bytes = Bytes::from_static(b"message");
 
-/// Publish redis command
-pub fn Publish<T, V>(key: T, value: V) -> utils::IntOutputCommand
-where
-    BulkString: From<T> + From<V>,
-{
-    utils::IntOutputCommand(Request::Array(vec![
-        Request::from_static("PUBLISH"),
-        Request::BulkString(key.into()),
-        Request::BulkString(value.into()),
-    ]))
-}
-
 #[derive(Debug, PartialEq)]
 pub enum SubscribeItem {
-    Subscribed,
-    UnSubscribed,
-    Message(Bytes),
+    Subscribed(Bytes),
+    UnSubscribed(Bytes),
+    Message { channel: Bytes, payload: Bytes },
+}
+
+struct MessagePayload(Either<Bytes, i64>);
+
+impl TryFrom<Response> for MessagePayload {
+    type Error = (&'static str, Response);
+
+    fn try_from(val: Response) -> Result<Self, Self::Error> {
+        match val {
+            Response::Bytes(bytes) => Ok(MessagePayload(Either::Left(bytes))),
+            Response::Integer(number) => Ok(MessagePayload(Either::Right(number))),
+            _ => Err(("Not a bytes object or integer", val)),
+        }
+    }
 }
 
 impl TryFrom<Response> for SubscribeItem {
     type Error = CommandError;
 
     fn try_from(val: Response) -> Result<Self, Self::Error> {
-        let parts = if let Response::Array(ref parts) = val {
-            parts
-        } else {
-            return Err(CommandError::Output("Cannot parse response", val));
-        };
-
-        if parts.len() != 3 {
-            return Err(CommandError::Output(
-                "Subscription message has invalid items number",
-                val,
-            ));
-        }
-
-        let (mtype, payload) = (&parts[0], &parts[2]);
-
-        let mtype = if let Response::Bytes(mtype) = mtype {
-            mtype
-        } else {
-            return Err(CommandError::Output(
-                "Subscription message type unknown",
-                val,
-            ));
-        };
+        let (mtype, channel, payload) = <(Bytes, Bytes, MessagePayload)>::try_from(val)?;
 
         if mtype == &TYPE_SUBSCRIBE {
-            return Ok(SubscribeItem::Subscribed);
+            return Ok(SubscribeItem::Subscribed(channel));
         }
 
         if mtype == &TYPE_UNSUBSCRIBE {
-            return Ok(SubscribeItem::UnSubscribed);
+            return Ok(SubscribeItem::UnSubscribed(channel));
         }
 
         if mtype != &TYPE_MESSAGE {
             return Err(CommandError::Output(
                 "Subscription message type unknown",
-                val,
+                Response::Bytes(mtype),
             ));
         }
 
-        if let Response::Bytes(payload) = payload {
-            return Ok(SubscribeItem::Message(payload.clone()));
+        let payload = if let Some(payload) = payload.0.left() {
+            payload
         } else {
             return Err(CommandError::Output(
-                "Subscription message has empty payload",
-                val,
+                "Subscription message payload is not bytes",
+                Response::Nil,
             ));
-        }
+        };
+
+        Ok(SubscribeItem::Message { channel, payload })
     }
 }
 
@@ -93,6 +75,18 @@ impl Command for SubscribeOutputCommand {
     fn to_output(val: Response) -> Result<Self::Output, CommandError> {
         SubscribeItem::try_from(val)
     }
+}
+
+/// Publish redis command
+pub fn Publish<T, V>(key: T, value: V) -> utils::IntOutputCommand
+where
+    BulkString: From<T> + From<V>,
+{
+    utils::IntOutputCommand(Request::Array(vec![
+        Request::from_static("PUBLISH"),
+        Request::BulkString(key.into()),
+        Request::BulkString(value.into()),
+    ]))
 }
 
 /// Subscribe redis command

--- a/src/cmd/pubsub.rs
+++ b/src/cmd/pubsub.rs
@@ -5,6 +5,7 @@ use std::convert::TryFrom;
 use crate::codec::{BulkString, Request, Response};
 
 const TYPE_SUBSCRIBE: Bytes = Bytes::from_static(b"subscribe");
+const TYPE_UNSUBSCRIBE: Bytes = Bytes::from_static(b"unsubscribe");
 const TYPE_MESSAGE: Bytes = Bytes::from_static(b"message");
 
 /// Publish redis command
@@ -22,6 +23,7 @@ where
 #[derive(Debug, PartialEq)]
 pub enum SubscribeItem {
     Subscribed,
+    UnSubscribed,
     Message(Bytes),
 }
 
@@ -55,6 +57,10 @@ impl TryFrom<Response> for SubscribeItem {
 
         if mtype == &TYPE_SUBSCRIBE {
             return Ok(SubscribeItem::Subscribed);
+        }
+
+        if mtype == &TYPE_UNSUBSCRIBE {
+            return Ok(SubscribeItem::UnSubscribed);
         }
 
         if mtype != &TYPE_MESSAGE {
@@ -96,6 +102,17 @@ where
 {
     SubscribeOutputCommand(Request::Array(vec![
         Request::from_static("SUBSCRIBE"),
+        Request::BulkString(key.into()),
+    ]))
+}
+
+/// Unsubscribe redis command
+pub fn UnSubscribe<T>(key: T) -> SubscribeOutputCommand
+where
+    BulkString: From<T>,
+{
+    SubscribeOutputCommand(Request::Array(vec![
+        Request::from_static("UNSUBSCRIBE"),
         Request::BulkString(key.into()),
     ]))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ mod simple;
 
 pub use self::client::{Client, CommandResult};
 pub use self::connector::RedisConnector;
-pub use self::simple::SimpleClient;
+pub use self::simple::{SimpleClient, SubscriptionClient};
 
 /// Macro to create a request array, useful for preparing commands to send. Elements can be any type, or a mixture
 /// of types, that satisfy `Into<Request>`.

--- a/src/simple.rs
+++ b/src/simple.rs
@@ -1,10 +1,10 @@
-use std::task::Poll;
-
-use ntex::{io::IoBoxed, io::RecvError, util::poll_fn, util::ready};
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use super::cmd::Command;
 use super::codec::Codec;
 use super::errors::{CommandError, Error};
+use ntex::{io::IoBoxed, io::RecvError, util::poll_fn, util::ready, util::Stream};
 
 /// Redis client
 pub struct SimpleClient {
@@ -46,7 +46,59 @@ impl SimpleClient {
         .await
     }
 
+    /// Execute redis command and stream response
+    pub fn stream<U>(
+        self,
+        cmd: U,
+    ) -> Result<impl Stream<Item = Result<U::Output, CommandError>>, CommandError>
+    where
+        U: Command,
+    {
+        self.io.encode(cmd.to_request(), &Codec)?;
+
+        let rs: RedisStream<U> = RedisStream {
+            io: self.io,
+            _cmd: std::marker::PhantomData,
+        };
+
+        Ok(rs)
+    }
+
     pub(crate) fn into_inner(self) -> IoBoxed {
         self.io
+    }
+}
+
+pub struct RedisStream<U: Command> {
+    io: IoBoxed,
+    _cmd: std::marker::PhantomData<U>,
+}
+
+impl<U: Command> Stream for RedisStream<U> {
+    type Item = Result<U::Output, CommandError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match ready!(self.io.poll_recv(&Codec, cx)) {
+            Ok(item) => match item.into_result() {
+                Ok(result) => Poll::Ready(Some(U::to_output(result))),
+                Err(err) => Poll::Ready(Some(Err(CommandError::Error(err)))),
+            },
+            Err(RecvError::KeepAlive) | Err(RecvError::Stop) => {
+                unreachable!()
+            }
+            Err(RecvError::WriteBackpressure) => {
+                if let Err(err) = ready!(self.io.poll_flush(cx, false))
+                    .map_err(|e| CommandError::Protocol(Error::PeerGone(Some(e))))
+                {
+                    Poll::Ready(Some(Err(err)))
+                } else {
+                    Poll::Pending
+                }
+            }
+            Err(RecvError::Decoder(err)) => Poll::Ready(Some(Err(CommandError::Protocol(err)))),
+            Err(RecvError::PeerGone(err)) => {
+                Poll::Ready(Some(Err(CommandError::Protocol(Error::PeerGone(err)))))
+            }
+        }
     }
 }

--- a/src/simple.rs
+++ b/src/simple.rs
@@ -26,7 +26,11 @@ impl SimpleClient {
         U: Command,
     {
         self.send(cmd)?;
-        self.recv::<U>().await.unwrap()
+        loop {
+            if let Some(result) = self.recv::<U>().await {
+                return result;
+            }
+        }
     }
 
     /// Send redis command

--- a/src/simple.rs
+++ b/src/simple.rs
@@ -93,7 +93,7 @@ impl<'a, U: Command> Stream for OutputStream<'a, U> {
     type Item = Result<U::Output, CommandError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.client.poll_recv::<U>(cx)
+        self.poll_recv(cx)
     }
 }
 

--- a/src/simple.rs
+++ b/src/simple.rs
@@ -115,7 +115,7 @@ impl<U: Command + PubSubCommand> SubscriptionClient<U> {
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let redis = RedisConnector::new("127.0.0.1:6379").connect_simple().await?;
     ///    
-    ///     let subscriber = redis.subscribe(cmd::Subscribe("test"))?;
+    ///     let subscriber = redis.subscribe(cmd::Subscribe(vec!["test"]))?;
     ///     // do some work
     ///
     ///     // go back to normal client

--- a/tests/test_redis.rs
+++ b/tests/test_redis.rs
@@ -211,6 +211,7 @@ async fn test_pubsub() {
         .unwrap();
 
     let stream = subscriber.stream(cmd::Subscribe(&key)).unwrap();
+
     let message = stream.recv().await;
     assert_eq!(message.unwrap().unwrap(), cmd::SubscribeItem::Subscribed);
 
@@ -226,4 +227,10 @@ async fn test_pubsub() {
         message.unwrap().unwrap(),
         cmd::SubscribeItem::Message(Bytes::from_static(b"1"))
     );
+
+    // unsub
+    subscriber.send(cmd::UnSubscribe(&key)).unwrap();
+
+    let message = stream.recv().await;
+    assert_eq!(message.unwrap().unwrap(), cmd::SubscribeItem::UnSubscribed);
 }

--- a/tests/test_redis.rs
+++ b/tests/test_redis.rs
@@ -1,4 +1,3 @@
-use futures_util::StreamExt;
 use ntex::util::{Bytes, HashMap};
 use ntex_redis::{cmd, Client, RedisConnector};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
@@ -211,8 +210,8 @@ async fn test_pubsub() {
         .await
         .unwrap();
 
-    let mut stream = subscriber.stream(cmd::Subscribe(&key)).unwrap();
-    let message = stream.next().await;
+    let stream = subscriber.stream(cmd::Subscribe(&key)).unwrap();
+    let message = stream.recv().await;
     assert_eq!(message.unwrap().unwrap(), cmd::SubscribeItem::Subscribed);
 
     let publisher = connect().await;
@@ -222,7 +221,7 @@ async fn test_pubsub() {
     assert_eq!(result, 1);
 
     // sub
-    let message = stream.next().await;
+    let message = stream.recv().await;
     assert_eq!(
         message.unwrap().unwrap(),
         cmd::SubscribeItem::Message(Bytes::from_static(b"1"))

--- a/tests/test_redis.rs
+++ b/tests/test_redis.rs
@@ -242,4 +242,8 @@ async fn test_pubsub() {
         message.unwrap().unwrap(),
         cmd::SubscribeItem::UnSubscribed(channel.clone())
     );
+
+    // back to client state
+    let client = pubsub.into_client();
+    client.exec(cmd::Reset()).await.unwrap();
 }

--- a/tests/test_redis.rs
+++ b/tests/test_redis.rs
@@ -211,9 +211,9 @@ async fn test_pubsub() {
         .await
         .unwrap();
 
-    let stream = subscriber.stream(cmd::Subscribe(&channel)).unwrap();
-
-    let message = stream.recv().await;
+    // sub
+    let pubsub = subscriber.subscribe(cmd::Subscribe(&channel)).unwrap();
+    let message = pubsub.recv().await;
     assert_eq!(
         message.unwrap().unwrap(),
         cmd::SubscribeItem::Subscribed(channel.clone())
@@ -225,8 +225,8 @@ async fn test_pubsub() {
     let result = publisher.exec(cmd::Publish(&channel, "1")).await.unwrap();
     assert_eq!(result, 1);
 
-    // sub
-    let message = stream.recv().await;
+    // receive message
+    let message = pubsub.recv().await;
     assert_eq!(
         message.unwrap().unwrap(),
         cmd::SubscribeItem::Message {
@@ -236,9 +236,8 @@ async fn test_pubsub() {
     );
 
     // unsub
-    subscriber.send(cmd::UnSubscribe(&channel)).unwrap();
-
-    let message = stream.recv().await;
+    pubsub.send(cmd::UnSubscribe(&channel)).unwrap();
+    let message = pubsub.recv().await;
     assert_eq!(
         message.unwrap().unwrap(),
         cmd::SubscribeItem::UnSubscribed(channel.clone())


### PR DESCRIPTION
Hi!

This is simplest pubsub implementation.
Currently works subscribe to one key, and publish to it;
Only for simple client.
And some names are horrible - for example `SimpleClient::stream` and `pubsub::SubscribeItem` where redis has own `stream` feature. Implementing in future redis `stream` features may cause names collisions 


