### PR TITLE
fix decode array if received uncomplete data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+* Fix decode uncomple array data
+
 ## [0.4.0] - 2023-01-04
 
 * 0.4 Release


### PR DESCRIPTION
Hi!
This PR must fix #6  (as it usually happens - while asking the question found a solution)

Solution - on decode array all items must be present in buffer
Each array item must have 2 `\r\n`

`*2\r\n$5\r\nhello\r\n$5\r\nworld\r\n`
https://redis.io/docs/reference/protocol-spec/#resp-arrays